### PR TITLE
Add option to set Accept header

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ Options:
           sets up a random User-Agent header to be used by the HTTP client
       --proxy <proxy>
           configure the HTTP client to use a proxy
+  -A, --accept <accept>
+         Accept header to be used by the HTTP client
   -r, --retry <retry>
           configure the number of retries in case of network error [default: 10]
       --connectionTimeoutSecs <connectionTimeoutSecs>

--- a/src/args.rs
+++ b/src/args.rs
@@ -77,6 +77,14 @@ fn command() -> Command {
                 .num_args(1)
                 .required(false),
         )
+        .arg(
+            Arg::new("accept")
+                .help("Accept header to be used by the HTTP client request")
+                .long("accept")
+                .short('A')
+                .num_args(1)
+                .required(false),
+        )
 }
 
 pub struct Arguments {
@@ -87,6 +95,7 @@ pub struct Arguments {
     pub proxy: Option<String>,
     pub retry: usize,
     pub connection_timeout_secs: usize,
+    pub accept: Option<String>,
 }
 
 pub fn get_args() -> Result<Arguments, DlmError> {
@@ -145,6 +154,8 @@ pub fn get_args() -> Result<Arguments, DlmError> {
         .cloned()
         .expect("impossible");
 
+    let accept = matches.get_one::<String>("accept").cloned();
+
     Ok(Arguments {
         input_file,
         max_concurrent_downloads,
@@ -153,6 +164,7 @@ pub fn get_args() -> Result<Arguments, DlmError> {
         proxy,
         retry,
         connection_timeout_secs,
+        accept,
     })
 }
 

--- a/src/downloader.rs
+++ b/src/downloader.rs
@@ -21,6 +21,7 @@ pub async fn download_link(
     output_dir: &str,
     pb_dl: &ProgressBar,
     pb_manager: &ProgressBarManager,
+    accept_header: &Option<String>,
 ) -> Result<String, DlmError> {
     let file_link = FileLink::new(raw_link.to_string())?;
     let (extension, filename_without_extension) = match file_link.extension {
@@ -88,6 +89,10 @@ pub async fn download_link(
             let mut request = client.get(url);
             if let Some(range) = query_range {
                 request = request.header("Range", range)
+            }
+
+            if let Some(accept) = accept_header {
+                request = request.header("Accept", accept)
             }
 
             // initiate file download

--- a/src/downloader.rs
+++ b/src/downloader.rs
@@ -53,7 +53,12 @@ pub async fn download_link(
         Ok(msg)
     } else {
         let url = file_link.url.as_str();
-        let head_result = client.head(url).send().await?;
+        let mut head_request = client.head(url);
+        if let Some(accept) = accept_header {
+            head_request = head_request.header("Accept", accept);
+        }
+
+        let head_result = head_request.send().await?;
         if !head_result.status().is_success() {
             let status_code = format!("{}", head_result.status());
             Err(DlmError::ResponseStatusNotSuccess { status_code })

--- a/src/main.rs
+++ b/src/main.rs
@@ -44,6 +44,7 @@ async fn main_result() -> Result<(), DlmError> {
         proxy,
         retry,
         connection_timeout_secs,
+        accept,
     } = get_args()?;
 
     let nb_of_lines = count_non_empty_lines(&input_file).await?;
@@ -56,6 +57,7 @@ async fn main_result() -> Result<(), DlmError> {
     let c_ref = &client;
     let client_no_redirect = make_client(&user_agent, &proxy, false, connection_timeout_secs)?;
     let c_no_redirect_ref = &client_no_redirect;
+    let accept_ref = &accept;
     // trim trailing slash if any
     let od_ref = &output_dir
         .strip_suffix('/')
@@ -106,6 +108,7 @@ async fn main_result() -> Result<(), DlmError> {
                                 od_ref,
                                 &dl_pb,
                                 pbm_ref,
+                                accept_ref,
                             )
                         },
                         |e: &DlmError| retry_handler(e, pbm_ref, &link),


### PR DESCRIPTION
This PR adds an option to set the [`Accept` header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Accept) explicitly in the client. This is useful in the case that the server can hand back a better format e.g. `WebP` instead of JPEG, and the client simply has to let the server know.